### PR TITLE
Resolving `{.slideover--r}` overlay issue

### DIFF
--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -6,7 +6,7 @@
 }
 
 .slideover__container {
-    position: absolute;
+    position: fixed;
     top: 0;
     left: 0;
     width: 100%;


### PR DESCRIPTION
> This is a fix for Issue https://github.com/nrichers/slideover/issues/1.

## Video preview

![0-video-fix](https://github.com/user-attachments/assets/1fe5667a-f8d4-4275-a13a-6583926630ab)

## Explanation of changes

### .slideover__container 

```css
.slideover__container {
    z-index: 1;
}
```

This takes care of the navigational arrow being covered and inaccessible: [L15](https://github.com/validbeck/slideover/blob/63952ae10529b21635167643a6aa841fd1d19e0c/_extensions/nrichers/slideover/slideover.css#L15)

| Before | After |
|--|--|
|<img width="708" alt="1-z-index" src="https://github.com/user-attachments/assets/e735e30b-3c38-4a2b-a078-d4b3af6399ff" /> | <img width="737" alt="1-z-index-after" src="https://github.com/user-attachments/assets/5f7652f4-2201-466d-a9e1-182f0e011c24" />|

## .slideover--r.slideover__content

```css
.slideover--r.slideover__content {
    transform: translateY(-50%) translateX(calc(100% - 60px));
}
```

This gives the collapsed right modal some room to breathe against the newly visible navigational arrow: [L46](https://github.com/validbeck/slideover/blob/63952ae10529b21635167643a6aa841fd1d19e0c/_extensions/nrichers/slideover/slideover.css#L46)

| Before | After |
|--|--|
|![Screenshot 2025-05-23 at 3 09 51 PM](https://github.com/user-attachments/assets/c678c7ca-baf2-4cf2-98e3-4c1717c4c64b) | <img width="100" alt="2-slideover-r-padding" src="https://github.com/user-attachments/assets/4ea1125d-67fe-4331-a895-bbe35d66f67a" />|

## .slideover--b.slideover__content 

```css
.slideover--b.slideover__content {
    transform: translateX(-50%) translateY(calc(100% - 70px));
}
```

Since the `ValidMind Academy` footer is now visible over the footer modal, same as the navigational arrow, this gives the collapsed bottom modal room to breathe against the footer: [L70](https://github.com/validbeck/slideover/blob/63952ae10529b21635167643a6aa841fd1d19e0c/_extensions/nrichers/slideover/slideover.css#L70)

| Before | After |
|--|--|
| <img width="1416" alt="4-bottom-padding" src="https://github.com/user-attachments/assets/02938c78-0b13-4c02-b643-337edf2f358a" />| <img width="1448" alt="5-bottom-new" src="https://github.com/user-attachments/assets/3e7468ff-3d62-473b-9192-0feaffa81b1f" />|

```css
.slideover--b.slideover__content {
  padding-bottom: 20px;
}
```
This gives the content of the footer room to breathe against the newly visible footer: [L80](https://github.com/validbeck/slideover/blob/63952ae10529b21635167643a6aa841fd1d19e0c/_extensions/nrichers/slideover/slideover.css#L80)

| Before | After |
|--|--|
|<img width="1435" alt="3-bottom-fix" src="https://github.com/user-attachments/assets/55b680b2-962b-4018-8e59-8a6c441d4619" /> | <img width="1393" alt="5-bottom-fixed" src="https://github.com/user-attachments/assets/d11e8283-7231-42cd-b20f-1f06acbf686a" />|