### PR TITLE
Add support for auto-collapse delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Install the extension with:
 quarto add nrichers/slideover
 ```
 
-## Usage
+## Usage examples
 
 To enable, add the extension to your YAML front matter:
 
@@ -34,43 +34,43 @@ format:
       - slideover
 ```
 
-For bottom slide-overs, use `.slideover--b`:
+Then add a slideover:
 
 ```md
 ::: {.slideover--b}
-This is an example that slides content over from the bottom.
+Slides content over from the bottom.
 :::
 ```
 
-For auto-collapsing slide-overs, add the `.auto-collapse` class:
 
 ```md
 ::: {.slideover--b .auto-collapse}
-This is an example that slides content over from the bottom and then auto-collapses after five seconds.
+Slides content over from the bottom and then auto-collapses after five seconds.
 :::
 ```
 
-For right slide-overs, use `.slideover--r`:
+```md
+::: {.slideover--b .auto-collapse-10}
+Slideover from the bottom that auto-collapses after 10 seconds.
+:::
+```
+
 
 ```md
 ::: {.slideover--r}
-This is an example that slides content over from the right.
+Slides content over from the right.
 :::
 ```
-
-For left slide-overs, use `.slideover--l`:
 
 ```md
 ::: {.slideover--l}
-This is an example that slides content over from the left.
+Slides content over from the left.
 :::
 ```
 
-For top slide-overs, use `.slideover--t`:
-
 ```md
 ::: {.slideover--t}
-This is an example that slides content over from the top.
+Slides content over from the top.
 :::
 ```
 
@@ -78,7 +78,7 @@ This is an example that slides content over from the top.
 
 - Slideover provides basic styling support for **bold** and _italic_ text
 - For advanced styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons)
-- Headings have special meaning to Quarto and Pandoc and are NOT supported inside slideovers.
+- Headings have special meaning in Quarto Revealjs presentations and are NOT supported inside slideovers.
 
 ## License
 

--- a/_extensions/nrichers/slideover/slideover.js
+++ b/_extensions/nrichers/slideover/slideover.js
@@ -135,9 +135,13 @@ var Plugin = {
                 });
                 
                 // Add auto-collapse functionality if the overlay has the auto-collapse class
-                if (overlay.classList.contains('auto-collapse')) {
+                if (overlay.classList.contains('auto-collapse') || Array.from(overlay.classList).some(cls => cls.startsWith('auto-collapse-'))) {
                     let autoCollapseTimer;
                     let userExpanded = false;
+                    
+                    // Get delay from auto-collapse-{s} class or use default 5s
+                    const delayClass = Array.from(overlay.classList).find(cls => cls.startsWith('auto-collapse-'));
+                    const delay = delayClass ? parseInt(delayClass.replace('auto-collapse-', '')) * 1000 : 5000;
                     
                     // Function to reset the timer
                     function resetAutoCollapseTimer(element) {
@@ -147,7 +151,7 @@ var Plugin = {
                                 element.classList.remove('slideover__content--active');
                                 element.querySelector('.slideover__toggle').classList.remove('slideover__toggle--active');
                             }
-                        }, 5000); // 5 seconds auto-collapse
+                        }, delay);
                     }
                     
                     // Start the timer

--- a/slideover.qmd
+++ b/slideover.qmd
@@ -37,17 +37,26 @@ Slideover text.
 
 Toggles the slideover after five seconds.
 
-::: {.slideover--b .auto-collapse}
+::: {.slideover--b .auto-collapse-10}
 Add `.auto-collapse` to the slideover:
 
 ```code
 ::: {.slideover--b .auto-collapse}
-Slideover text that collapses after five seconds.
+Slideover text that collapses after five seconds by default.
 :::
 ```
+
+Or, control the delay by suffixing a delay in second, like `.auto-collapse-10`:
+
+```code
+::: {.slideover--b .auto-collapse-10}
+Slideover text that auto-collapses after 10 seconds.
+:::
+``` 
+
 :::
 
-# From the<br>right,toggle<br>manually
+# From the <br>right, toggle <br>manually
 
 ::: {.slideover--r}
 
@@ -63,9 +72,9 @@ Slideover text.
 
 :::
 
-# One more thing,<br>for the lefties.
+# One for the lefties.
 
-::: {.slideover--l .auto-collapse}
+::: {.slideover--l .auto-collapse-10}
 
 Content can also slide over from the left side, sinisterly.
 
@@ -83,11 +92,11 @@ Yes, it's OK to be _sinister_. Take it from someone who is a left-handed and who
 
 :::
 
-# And from the top, too.
+# <br>And from the top, too.
 
 ::: {.slideover--t}
 
-Content can also slide over from the top.
+And, finally, content can also slide over from the top.
 
 **Usage example**
 
@@ -101,6 +110,6 @@ Slideover text from the top.
 
 - Slideover provides only limited styling support.<br>For example, **bolding** and _italics_ are supported.
 - For better styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons).
-- Headings have special meaning to Quarto and Pandoc and are NOT supported inside slideovers.
+- Headings have special meaning in Quarto Revealjs presentations and are NOT supported inside slideovers.
 
 :::


### PR DESCRIPTION
Closes #3: Add a configurable delay (in seconds) that can be suffixed to auto-collapsing slideovers.

Usage example:

```
::: {.slideover--b .auto-collapse-10}
Slideover from the bottom that auto-collapses after 10 seconds.
:::
```

Output example: 
 
![2025-05-25_09-24-37 (1)](https://github.com/user-attachments/assets/6839def0-c4b3-4a47-a37a-d2fa2908a24b)
