### PR TITLE
Beck/half width slide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,9 +76,20 @@ Slides content over from the top.
 
 ## Tips & Tricks
 
-- Slideover provides basic styling support for **bold** and _italic_ text
-- For advanced styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons)
+- Slideover provides basic styling support for **bold** and _italic_ text.
+- For advanced styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons).
 - Headings have special meaning in Quarto Revealjs presentations and are NOT supported inside slideovers.
+- You can also modify the default size (40% for right or left, 80% for top or bottom) of any of the slideovers for more or less screen real estate:
+  - `.quarters` — 3/4s or 75% of the default width.
+  - `.half` — 1/2s or 50% of the default width.
+  - `.third` — 1/3 or 33ish% of the default width.
+
+  For example:
+    ```md
+    ::: {.slideover--t .half}
+    Slides content over from the top, at half-size.
+    :::
+    ```
 
 ## License
 

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -3,11 +3,21 @@
 
 :root {
     --slideover-default-width: 40vw;
+    --slideover-quarter-width: calc(var(--slideover-default-width) * 0.75);
     --slideover-half-width: calc(var(--slideover-default-width) / 2);
+    --slideover-third-width: calc(var(--slideover-default-width) / 3);
+}
+
+.slideover__content.quarters {
+    width: var(--slideover-quarter-width) !important;
 }
 
 .slideover__content.half {
-    width: var(--slideover-half-width);
+    width: var(--slideover-half-width) !important;
+}
+
+.slideover__content.third {
+    width: var(--slideover-third-width) !important;
 }
 
 .slideover__presentation {

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -5,8 +5,8 @@
     --slideover-default-lr: 40vw;
     --slideover-default-tb: 80vw;
 
-    --slideover-quarter-lr: calc(var(--slideover-default-lr) * 0.75);
-    --slideover-quarter-tb: calc(var(--slideover-default-tb) * 0.75);
+    --slideover-quarters-lr: calc(var(--slideover-default-lr) * 0.75);
+    --slideover-quarters-tb: calc(var(--slideover-default-tb) * 0.75);
 
     --slideover-half-lr: calc(var(--slideover-default-lr) / 2);
     --slideover-half-tb: calc(var(--slideover-default-tb) / 2);

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -1,6 +1,15 @@
 /* Import Inter font from Google Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+:root {
+    --slideover-default-width: 40vw;
+    --slideover-half-width: calc(var(--slideover-default-width) / 2);
+}
+
+.slideover__content.half {
+    width: var(--slideover-half-width);
+}
+
 .slideover__presentation {
     position: relative;
 }
@@ -40,7 +49,7 @@
     left: auto;
     height: auto;
     max-height: 80vh;
-    width: 40vw;
+    width: var(--slideover-default-width);
     max-width: 100vw;
     box-sizing: border-box;
     transform: translateY(-50%) translateX(calc(100% - 60px));
@@ -327,7 +336,7 @@
     right: auto;
     height: auto;
     max-height: 80vh;
-    width: 40vw;
+    width: var(--slideover-default-width);
     max-width: 100vw;
     box-sizing: border-box;
     transform: translateY(-50%) translateX(calc(-100% + 60px));

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -2,22 +2,49 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
 :root {
-    --slideover-default-width: 40vw;
-    --slideover-quarter-width: calc(var(--slideover-default-width) * 0.75);
-    --slideover-half-width: calc(var(--slideover-default-width) / 2);
-    --slideover-third-width: calc(var(--slideover-default-width) / 3);
+    --slideover-default-lr: 40vw;
+    --slideover-default-tb: 80vw;
+
+    --slideover-quarter-lr: calc(var(--slideover-default-lr) * 0.75);
+    --slideover-quarter-tb: calc(var(--slideover-default-tb) * 0.75);
+
+    --slideover-half-lr: calc(var(--slideover-default-lr) / 2);
+    --slideover-half-tb: calc(var(--slideover-default-tb) / 2);
+
+    --slideover-third-lr: calc(var(--slideover-default-lr) / 3);
+    --slideover-third-tb: calc(var(--slideover-default-tb) / 3);
 }
 
-.slideover__content.quarters {
-    width: var(--slideover-quarter-width) !important;
+/* Modifiers for half, third, three quarters (LR) */
+.slideover--l.slideover__content.half,
+.slideover--r.slideover__content.half {
+    width: var(--slideover-half-lr) !important;
 }
 
-.slideover__content.half {
-    width: var(--slideover-half-width) !important;
+.slideover--l.slideover__content.third,
+.slideover--r.slideover__content.third {
+    width: var(--slideover-third-lr) !important;
 }
 
-.slideover__content.third {
-    width: var(--slideover-third-width) !important;
+.slideover--l.slideover__content.quarters,
+.slideover--r.slideover__content.quarters {
+    width: var(--slideover-quarters-lr) !important;
+}
+
+/* Modifiers for half, third, three quarters (TB) */
+.slideover--t.slideover__content.half,
+.slideover--b.slideover__content.half {
+    width: var(--slideover-half-tb) !important;
+}
+
+.slideover--t.slideover__content.third,
+.slideover--b.slideover__content.third {
+    width: var(--slideover-third-tb) !important;
+}
+
+.slideover--t.slideover__content.quarters,
+.slideover--b.slideover__content.quarters {
+    width: var(--slideover-quarters-tb) !important;
 }
 
 .slideover__presentation {
@@ -59,7 +86,7 @@
     left: auto;
     height: auto;
     max-height: 80vh;
-    width: var(--slideover-default-width);
+    width: var(--slideover-default-lr);
     max-width: 100vw;
     box-sizing: border-box;
     transform: translateY(-50%) translateX(calc(100% - 60px));
@@ -88,7 +115,7 @@
     left: 50%;
     transform: translateX(-50%) translateY(calc(100% - 70px));
     top: auto;
-    width: 80%;
+    width: var(--slideover-default-tb);
     height: auto;
     max-height: 40vh;
     border-radius: 8px 8px 0 0;
@@ -107,7 +134,7 @@
     left: 50%;
     transform: translateX(-50%) translateY(calc(-100% + 70px));
     bottom: auto;
-    width: 80%;
+    width: var(--slideover-default-tb);
     height: auto;
     max-height: 40vh;
     border-radius: 0 0 8px 8px;
@@ -346,7 +373,7 @@
     right: auto;
     height: auto;
     max-height: 80vh;
-    width: var(--slideover-default-width);
+    width: var(--slideover-default-lr);
     max-width: 100vw;
     box-sizing: border-box;
     transform: translateY(-50%) translateX(calc(-100% + 60px));

--- a/_extensions/nrichers/slideover/slideover.js
+++ b/_extensions/nrichers/slideover/slideover.js
@@ -87,6 +87,13 @@ var Plugin = {
                 if (overlay.classList.contains('slideover--t')) {
                     content.classList.add('slideover--t');
                 }
+
+                // Add any additional modifier classes
+                overlay.classList.forEach(cls => {
+                    if (!['slideover--r', 'slideover--b', 'slideover--l', 'slideover--t'].includes(cls)) {
+                        content.classList.add(cls);
+                    }
+                });
                 
                 // Create header
                 const header = document.createElement('div');

--- a/slideover.qmd
+++ b/slideover.qmd
@@ -114,20 +114,28 @@ Slideover text from the top.
 
 :::
 
-# Mad science, it works. 
+# Mad science, it works.
 
-::: {.slideover--l}
-Slides content over from the left.
+::: {.slideover--l .third}
+Slides content over from the left, at at third of the size.
 :::
 
-::: {.slideover--b}
-Slides content over from the bottom.
+::: {.slideover--b .quarters}
+Slides content over from the bottom, at three-quarters of the size.
+
+You can use the size adjustments on any slideover type.
 :::
 
-::: {.slideover--r}
-Slides content over from the right.
+::: {.slideover--r .half}
+Slides content over from the right, at half-size.
 :::
 
 ::: {.slideover--t}
-Slides content over from the top.
+Slides content over from the top, with the default size at 40% width.
+
+You can additionally include the following classes to decrease the default width of the slideovers, for modals with less content:
+
+- `.quarters` — 3/4s or 75% of the default 40% width.
+- `.half` — 1/2s or 50% of the default 40% width.
+- `.third` — 1/3 or 33ish% of the default 40% width.
 :::

--- a/slideover.qmd
+++ b/slideover.qmd
@@ -117,25 +117,28 @@ Slideover text from the top.
 # Mad science, it works.
 
 ::: {.slideover--l .third}
-Slides content over from the left, at at third of the size.
+Slide content over from the left, at at third of the size.
 :::
 
 ::: {.slideover--b .quarters}
-Slides content over from the bottom, at three-quarters of the size.
+Slide content over from the bottom, at three-quarters of the size.
 
 You can use the size adjustments on any slideover type.
 :::
 
 ::: {.slideover--r .half}
-Slides content over from the right, at half-size.
+Slide content over from the right, at half-size.
 :::
 
 ::: {.slideover--t}
-Slides content over from the top, with the default size at 40% width.
+Slide content over from the top, with the default width.
+
+- **Default width for left or right:** 40%
+- **Default width for top or bottom:** 80%
 
 You can additionally include the following classes to decrease the default width of the slideovers, for modals with less content:
 
-- `.quarters` — 3/4s or 75% of the default 40% width.
-- `.half` — 1/2s or 50% of the default 40% width.
-- `.third` — 1/3 or 33ish% of the default 40% width.
+- `.quarters` — 3/4s or 75% of the default width.
+- `.half` — 1/2s or 50% of the default width.
+- `.third` — 1/3 or 33ish% of the default width.
 :::


### PR DESCRIPTION
This fixes issue https://github.com/nrichers/slideover/issues/7.

## Preview

![Screenshot 2025-05-27 at 3 03 34 PM](https://github.com/user-attachments/assets/e4bdbeb4-561f-4c15-b581-7011ed8f2b65)

### Updated README

![Screenshot 2025-05-27 at 3 04 20 PM](https://github.com/user-attachments/assets/f0b8809d-fdd7-4106-bf51-9360fb89f156)

## How it works

1. Establishing the default and adjusted widths under `:root` in CSS: 
```
:root {
    --slideover-default-lr: 40vw;
    --slideover-default-tb: 80vw;

    --slideover-quarters-lr: calc(var(--slideover-default-lr) * 0.75);
    --slideover-quarters-tb: calc(var(--slideover-default-tb) * 0.75);

    --slideover-half-lr: calc(var(--slideover-default-lr) / 2);
    --slideover-half-tb: calc(var(--slideover-default-tb) / 2);

    --slideover-third-lr: calc(var(--slideover-default-lr) / 3);
    --slideover-third-tb: calc(var(--slideover-default-tb) / 3);
}
```

2. Specific width classes for left-right and top-bottom widths in CSS:

```
/* Modifiers for half, third, three quarters (LR) */
.slideover--l.slideover__content.half,
.slideover--r.slideover__content.half {
    width: var(--slideover-half-lr) !important;
}

.slideover--l.slideover__content.third,
.slideover--r.slideover__content.third {
    width: var(--slideover-third-lr) !important;
}

.slideover--l.slideover__content.quarters,
.slideover--r.slideover__content.quarters {
    width: var(--slideover-quarters-lr) !important;
}

/* Modifiers for half, third, three quarters (TB) */
.slideover--t.slideover__content.half,
.slideover--b.slideover__content.half {
    width: var(--slideover-half-tb) !important;
}

.slideover--t.slideover__content.third,
.slideover--b.slideover__content.third {
    width: var(--slideover-third-tb) !important;
}

.slideover--t.slideover__content.quarters,
.slideover--b.slideover__content.quarters {
    width: var(--slideover-quarters-tb) !important;
}
```

3. Specify the default width in the element to be overwritten via the variable, for example this left-right default in right within the CSS:
```
.slideover--r.slideover__content {
    top: 50%;
    right: 0;
    left: auto;
    height: auto;
    max-height: 80vh;
    width: var(--slideover-default-lr);
    max-width: 100vw;
    box-sizing: border-box;
    transform: translateY(-50%) translateX(calc(100% - 60px));
    transition: transform 0.3s cubic-bezier(.4,0,.2,1);
    display: flex;
    flex-direction: column;
    padding: 20px;
    border-radius: 8px 0 0 8px;
    overflow: hidden;
}
```

4. Add the additional width modifier classes within the JavaScript:
```
                // Add any additional modifier classes
                overlay.classList.forEach(cls => {
                    if (!['slideover--r', 'slideover--b', 'slideover--l', 'slideover--t'].includes(cls)) {
                        content.classList.add(cls);
                    }
                });
```