### PR TITLE
More flexible custom styling

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,10 +76,15 @@ Slides content over from the top.
 
 ## Tips & Tricks
 
-- Slideover provides basic styling support for **bold** and _italic_ text.
-- For advanced styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons).
 - Headings have special meaning in Quarto Revealjs presentations and are NOT supported inside slideovers.
-- You can also modify the default size (40% for right or left, 80% for top or bottom) of any of the slideovers for more or less screen real estate:
+- To insert a callout within a slideover, use the `.embed` class:
+  ```md
+  ::: {.slideover--l}
+  ::: {.embed}
+  This is an embedded callout within a left-aligned slideover.
+  :::
+  :::
+- You can modify the default size (40% for right or left, 80% for top or bottom) of any of the slideovers for more or less screen real estate:
   - `.three-quarters` — 3/4s or 75% of the default width.
   - `.half` — 1/2s or 50% of the default width.
   - `.third` — 1/3 or 33ish% of the default width.
@@ -90,6 +95,12 @@ Slides content over from the top.
     Slides content over from the top, at half-size.
     :::
     ```
+
+## Custom styling
+
+- Slideover provides basic styling support for elements such as: links, emphasis, embedded callouts, quotations, and code blocks.
+- To adjust basic elements in the default theme, edit [`custom-slideover.css`](_extensions/nrichers/slideover/custom-slideover.css) to your liking.
+- For advanced styling, use [Tachyons Extension For Quarto](https://github.com/nareal/tachyons).
 
 ## License
 

--- a/_extensions/nrichers/slideover/_extension.yml
+++ b/_extensions/nrichers/slideover/_extension.yml
@@ -8,4 +8,5 @@ contributes:
       script:
         - slideover.js
       stylesheet:
-        - slideover.css 
+        - slideover.css
+        - custom-slideover.css

--- a/_extensions/nrichers/slideover/_extension.yml
+++ b/_extensions/nrichers/slideover/_extension.yml
@@ -1,6 +1,6 @@
 title: Reveal.js Slideover
 author: Nik Richers
-version: 1.2.0
+version: 1.3.0
 quarto-required: ">=1.6.0"
 contributes:
   revealjs-plugins:

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -5,35 +5,11 @@
     --slideover-default-border: 1px solid #083e44;;
 }
 
-/* Global slideover container styling */
+/* Global slideover styling */
 .slideover__content {
     background: var(--slideover-default-bg) !important;
     color: var(--slideover-default-text) !important;
     border: var(--slideover-default-border) !important;
-}
-
-/* Slideover header global styling */
-.slideover__header {
-    background: var(--slideover-default-bg) !important;
-}
-
-/* Global slideover content area styling */
-.slideover__content-area {
-    background: var(--slideover-default-bg) !important;
-    color: var(--slideover-default-text) !important;
-}
-
-.slideover--b .slideover__content-area {
-    background: var(--slideover-default-bg) !important;
-}
-
-.slideover--t .slideover__content-area {
-    background: var(--slideover-default-bg) !important;
-}
-
-/* Toggle-arrow styling */
-.slideover__toggle {
-    color: var(--slideover-default-text) !important;
 }
 
 /* Right-aligned styling */

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -1,0 +1,29 @@
+/* Global variables */
+:root {
+    --slideover-default-bg: 40vw;
+    --slideover-default-text: 80vw;
+    --slideover-default-border: 80vw;
+}
+
+/* Right-aligned styling */
+
+/* Bottom-aligned styling */
+
+/* Left-aligned styling */
+
+/* Top-aligned styling */
+
+/* Bold text styling */
+
+/* Link styling */
+
+/* Link hover state styling */
+
+/* Optional embedded callout styling */
+
+/* Blockquote styling */
+
+/* Code block styling */
+
+/* Inline code styling */
+

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -12,13 +12,25 @@
     border: var(--slideover-default-border) !important;
 }
 
-/* Right-aligned styling */
+/* Right-aligned emphasis border */
+.slideover--r.slideover__content {
+    border-left-width: 5px !important;
+}
 
-/* Bottom-aligned styling */
+/* Left-aligned emphasis border */
+.slideover--l.slideover__content {
+    border-right-width: 5px !important;
+}
 
-/* Left-aligned styling */
+/* Top-aligned emphasis border */
+.slideover--t.slideover__content {
+    border-bottom-width: 5px !important;
+}
 
-/* Top-aligned styling */
+/* Bottom-aligned emphasis border */
+.slideover--b.slideover__content {
+    border-top-width: 5px !important;
+}
 
 /* Bold text styling */
 

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -2,7 +2,9 @@
 :root {
     --slideover-default-bg: #eaf8fa;
     --slideover-default-text: #083e44;
-    --slideover-default-border: 1px solid #083e44;;
+    --slideover-default-border: 1px solid #083e44;
+    --slideover-default-links: #0000EE;
+    --slideover-default-accent: #555;
 }
 
 /* Global slideover styling */
@@ -14,35 +16,64 @@
 
 /* Right-aligned emphasis border */
 .slideover--r.slideover__content {
-    border-left-width: 5px !important;
+    /* border-left-width: 5px !important; */
 }
 
 /* Left-aligned emphasis border */
 .slideover--l.slideover__content {
-    border-right-width: 5px !important;
+    /* border-right-width: 5px !important; */
 }
 
 /* Top-aligned emphasis border */
 .slideover--t.slideover__content {
-    border-bottom-width: 5px !important;
+    /* border-bottom-width: 5px !important; */
 }
 
 /* Bottom-aligned emphasis border */
 .slideover--b.slideover__content {
-    border-top-width: 5px !important;
+    /* border-top-width: 5px !important; */
 }
-
-/* Bold text styling */
 
 /* Link styling */
 
-/* Link hover state styling */
+.slideover__content-area a {
+    color: var(--slideover-default-links);
+    /* text-decoration: none; */
+}
 
-/* Optional embedded callout styling */
+.slideover__content-area a:hover {
+  /* text-decoration: underline 2px solid var(--slideover-default-text); */
+}
 
-/* Blockquote styling */
+/* Callout embed styling */
+.slideover__content-area .embed {
+    background-color: white;
+    border: 1px solid rgba(8, 62, 68, 0.2);
+}
 
-/* Code block styling */
+/* Emphasis styling */
+.slideover__content-area strong {
+    color: var(--slideover-default-accent) !important;
+}
 
-/* Inline code styling */
+/* Quotation styling */
+.quote {
+    color: var(--slideover-default-accent) !important;
+    border-left: 3px solid var(--slideover-default-text) !important;
+} 
 
+.slideover__content-area blockquote {
+    border-left: 4px solid var(--slideover-default-text) !important;
+    color: var(--slideover-default-accent) !important;
+}
+
+/* Code styling */
+.slideover__content-area div.sourceCode {
+    background-color: var(--slideover-default-bg) !important;
+}
+
+.slideover__content-area code {
+    color: var(--slideover-default-text) !important;
+    background-color: white;
+    border: 1px solid rgba(8, 62, 68, 0.2);
+}

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -52,14 +52,16 @@
 }
 
 /* Emphasis styling */
-.slideover__content-area strong {
+.slideover__content-area strong,
+.slideover__content-area b,
+.slideover__content-area i,
+.slideover__content-area em {
     color: var(--slideover-default-accent) !important;
 }
 
 /* Quotation styling */
-.quote {
+q {
     color: var(--slideover-default-accent) !important;
-    border-left: 3px solid var(--slideover-default-text) !important;
 } 
 
 .slideover__content-area blockquote {

--- a/_extensions/nrichers/slideover/custom-slideover.css
+++ b/_extensions/nrichers/slideover/custom-slideover.css
@@ -1,8 +1,39 @@
 /* Global variables */
 :root {
-    --slideover-default-bg: 40vw;
-    --slideover-default-text: 80vw;
-    --slideover-default-border: 80vw;
+    --slideover-default-bg: #eaf8fa;
+    --slideover-default-text: #083e44;
+    --slideover-default-border: 1px solid #083e44;;
+}
+
+/* Global slideover container styling */
+.slideover__content {
+    background: var(--slideover-default-bg) !important;
+    color: var(--slideover-default-text) !important;
+    border: var(--slideover-default-border) !important;
+}
+
+/* Slideover header global styling */
+.slideover__header {
+    background: var(--slideover-default-bg) !important;
+}
+
+/* Global slideover content area styling */
+.slideover__content-area {
+    background: var(--slideover-default-bg) !important;
+    color: var(--slideover-default-text) !important;
+}
+
+.slideover--b .slideover__content-area {
+    background: var(--slideover-default-bg) !important;
+}
+
+.slideover--t .slideover__content-area {
+    background: var(--slideover-default-bg) !important;
+}
+
+/* Toggle-arrow styling */
+.slideover__toggle {
+    color: var(--slideover-default-text) !important;
 }
 
 /* Right-aligned styling */

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -399,8 +399,7 @@ q {
     font-weight: 700;
 }
 
-.slideover__content-area em,
-.slideover__content-area i {
+.slideover__content-area em {
     font-style: italic;
 }
 

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -82,6 +82,58 @@
     margin: 0;
 }
 
+/* Slideover header global styling */
+.slideover__header {
+    height: 40px;
+    display: flex;
+    align-items: left;
+    justify-content: left;
+    cursor: pointer;
+    flex-shrink: 0;
+    padding: 0 8px;
+    background: #eaf8fa;
+    margin: 0;
+    position: relative;
+    z-index: 3;
+    pointer-events: auto;
+}
+
+/* Global slideover content area styling */
+.slideover__content-area {
+    padding: 0 1.5rem 1.5rem;
+    overflow-y: auto;
+    background: #eaf8fa;
+    color: #083e44;
+    line-height: 1.5;
+    margin: -40px 0 0 0;
+    position: relative;
+    z-index: 2;
+    padding-top: 25px;
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
+}
+
+.slideover__content--active .slideover__content-area {
+    z-index: 3;
+}
+
+.slideover__content:not(.slideover__content--active) .slideover__content-area {
+    opacity: 0;
+    visibility: hidden;
+}
+
+.slideover__content-area p,
+.slideover__content-area div {
+    padding-block-start: 0.5em;
+}
+
+.slideover__content-area > *:first-child {
+    margin-top: 0;
+    padding-top: 0;
+    padding-block-start: 0;
+}
+
 /* Right-aligned slideover effects */
 .slideover--r.slideover__content {
     top: 50%;
@@ -155,11 +207,6 @@
     margin: -20px 0;
 }
 
-.slideover--l .slideover__content-area {
-    margin-top: -20px;
-    margin-bottom: -20px;
-}
-
 /* Bottom-aligned slideover effects */
 .slideover--b.slideover__content {
     bottom: 0;
@@ -176,6 +223,16 @@
     overflow: hidden;
     padding-bottom: 20px;
 }
+
+.slideover--b .slideover__content-area {
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 3rem;
+    padding-right: 3rem;
+    text-align: left;
+    background: #eaf8fa;
+}
+
 .slideover--b.slideover__content.slideover__content--active {
     transform: translateX(-50%) translateY(0);
 }
@@ -186,15 +243,6 @@
     margin: 0 -20px;
     border-radius: 8px 8px 0 0;
     background: transparent;
-}
-
-.slideover--b .slideover__content-area {
-    margin-left: -20px;
-    margin-right: -20px;
-    padding-left: 3rem;
-    padding-right: 3rem;
-    text-align: left;
-    background: #eaf8fa;
 }
 
 /* Top-aligned slideover effects */
@@ -213,18 +261,6 @@
     overflow: hidden;
 }
 
-.slideover--t.slideover__content.slideover__content--active {
-    transform: translateX(-50%) translateY(0);
-}
-
-.slideover--t .slideover__header {
-    justify-content: flex-end;
-    padding-right: 16px;
-    margin: 0 -20px;
-    border-radius: 0 0 8px 8px;
-    background: transparent;
-}
-
 .slideover--t .slideover__content-area {
     margin-left: -20px;
     margin-right: -20px;
@@ -235,20 +271,16 @@
     background: #eaf8fa;
 }
 
-/* Slideover header styling */
-.slideover__header {
-    height: 40px;
-    display: flex;
-    align-items: left;
-    justify-content: left;
-    cursor: pointer;
-    flex-shrink: 0;
-    padding: 0 8px;
-    background: #eaf8fa;
-    margin: 0;
-    position: relative;
-    z-index: 3;
-    pointer-events: auto;
+.slideover--t.slideover__content.slideover__content--active {
+    transform: translateX(-50%) translateY(0);
+}
+
+.slideover--t .slideover__header {
+    justify-content: flex-end;
+    padding-right: 16px;
+    margin: 0 -20px;
+    border-radius: 0 0 8px 8px;
+    background: transparent;
 }
 
 /* Toggle-arrow styling */
@@ -292,7 +324,7 @@
     left: auto;
 }
 
-/* Rotation logic: default (open), --active for closed */
+/* Toggle rotation logic: default (open), --active for closed */
 .slideover__content.slideover--r .slideover__toggle {
     transform: rotate(180deg); /* Open: left arrow */
 }
@@ -321,41 +353,6 @@
     transform: rotate(0deg); /* Closed: down arrow */
 }
 
-/* Global slideover content area styling */
-.slideover__content-area {
-    padding: 0 1.5rem 1.5rem;
-    overflow-y: auto;
-    background: #eaf8fa;
-    color: #083e44;
-    line-height: 1.5;
-    margin: -40px 0 0 0;
-    position: relative;
-    z-index: 2;
-    padding-top: 25px;
-    opacity: 1;
-    visibility: visible;
-    transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
-}
-
-.slideover__content--active .slideover__content-area {
-    z-index: 3;
-}
-
-.slideover__content:not(.slideover__content--active) .slideover__content-area {
-    opacity: 0;
-    visibility: hidden;
-}
-
-.slideover__content-area p,
-.slideover__content-area div {
-    padding-block-start: 0.5em;
-}
-
-.slideover__content-area > *:first-child {
-    margin-top: 0;
-    padding-top: 0;
-    padding-block-start: 0;
-}
 
 /* Mobile widths */
 @media screen and (max-width: 800px) {

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -107,10 +107,16 @@
     margin-top: -20px;
     margin-bottom: -20px;
     padding: 40px 1.5rem 1.5rem;
+    margin-top: -20px;
+    margin-bottom: -20px;
 }
 
 .slideover--r.slideover__content.slideover__content--active {
     transform: translateY(-50%) translateX(0);
+}
+
+.slideover--r .slideover__header {
+  margin: -20px 0;
 }
 
 /* Bottom-aligned slideover effects */
@@ -228,6 +234,23 @@
     stroke-width: 1px;
 }
 
+.slideover--r .slideover__toggle {
+  left: 8px;
+  right: auto;
+} 
+
+.slideover--l .slideover__toggle {
+    right: 8px;
+    left: auto;
+}
+
+.slideover--t .slideover__toggle {
+    top: auto;
+    bottom: 8px;
+    right: 8px;
+    left: auto;
+}
+
 /* Rotation logic: default (open), --active for closed */
 .slideover__content.slideover--r .slideover__toggle {
     transform: rotate(180deg); /* Open: left arrow */
@@ -293,21 +316,21 @@
     padding-block-start: 0;
 }
 
+/* Mobile widths */
 @media screen and (max-width: 800px) {
-    .slideover--r.slideover__content {
+    .slideover--r.slideover__content,
+    .slideover--l.slideover__content {
         max-height: 90vh;
         width: 90vw;
     }
-    .slideover--b.slideover__content {
-        width: 90%;
-        max-height: 60vh;
-    }
+    .slideover--b.slideover__content,
     .slideover--t.slideover__content {
         width: 90%;
         max-height: 60vh;
     }
 } 
 
+/* Other elements */
 .quote {
     font-style: italic;
     color: #555;
@@ -315,20 +338,6 @@
     padding-left: 1em;
     margin: 0.5em 0;
     display: inline-block;
-} 
-
-.slideover--r .slideover__toggle {
-  left: 8px;
-  right: auto;
-} 
-
-.slideover--r .slideover__header {
-  margin: -20px 0;
-}
-
-.slideover--r .slideover__content-area {
-  margin-top: -20px;
-  margin-bottom: -20px;
 } 
 
 .slideover__content-area strong {
@@ -410,10 +419,6 @@
     transform: translateY(-50%) translateX(0);
 }
 
-.slideover--l .slideover__toggle {
-    right: 8px;
-    left: auto;
-}
 
 .slideover--l .slideover__header {
     margin: -20px 0;
@@ -424,16 +429,3 @@
     margin-bottom: -20px;
 }
 
-@media screen and (max-width: 800px) {
-    .slideover--l.slideover__content {
-        max-height: 90vh;
-        width: 90vw;
-    }
-}
-
-.slideover--t .slideover__toggle {
-    top: auto;
-    bottom: 8px;
-    right: 8px;
-    left: auto;
-}

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -381,7 +381,7 @@
 }
 
 /* Quotations */
-.quote {
+q {
     font-style: italic;
     padding-left: 1em;
     margin: 0.5em 0;
@@ -394,11 +394,13 @@
 }
 
 /* Emphasis */
-.slideover__content-area strong {
+.slideover__content-area strong,
+.slideover__content-area b {
     font-weight: 700;
 }
 
-.slideover__content-area em {
+.slideover__content-area em,
+.slideover__content-area i {
     font-style: italic;
 }
 

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -134,6 +134,16 @@
     padding-block-start: 0;
 }
 
+.slideover__content-area p {
+    margin: 1em 0;
+}
+
+.slideover__content-area ul,
+.slideover__content-area ol {
+    margin: 1em 0;
+    padding-left: 2em;
+}
+
 /* Right-aligned slideover effects */
 .slideover--r.slideover__content {
     top: 50%;
@@ -369,6 +379,8 @@
 } 
 
 /* Other elements */
+
+/* Quotations */
 .quote {
     font-style: italic;
     color: #555;
@@ -378,6 +390,14 @@
     display: inline-block;
 } 
 
+.slideover__content-area blockquote {
+    border-left: 4px solid #083e44;
+    margin: 1em 0;
+    padding-left: 1em;
+    color: #555;
+}
+
+/* Emphasis */
 .slideover__content-area strong {
     font-weight: 700;
 }
@@ -386,23 +406,7 @@
     font-style: italic;
 }
 
-.slideover__content-area p {
-    margin: 1em 0;
-}
-
-.slideover__content-area ul,
-.slideover__content-area ol {
-    margin: 1em 0;
-    padding-left: 2em;
-}
-
-.slideover__content-area blockquote {
-    border-left: 4px solid #083e44;
-    margin: 1em 0;
-    padding-left: 1em;
-    color: #555;
-}
-
+/* Code blocks */
 .slideover__content-area div.sourceCode {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     color: #003b4f;

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -68,7 +68,6 @@
 /* Global slideover container styling */
 .slideover__content {
     position: fixed;
-    /* border: 1px solid #083e44; */
     box-shadow: -2px 0 4px rgba(8, 62, 68, 0.1), 0 0 4px rgba(8, 62, 68, 0.1);
     transition: transform 0.3s ease-in-out;
     pointer-events: auto;

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -410,7 +410,6 @@
 .slideover__content-area div.sourceCode {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
     color: #003b4f;
-    background-color: #f5fcfd;
     font-size: 0.9em;
     background-color: #f5fcfd;
     padding: 0.4em 0.6em;

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -1,6 +1,7 @@
 /* Import Inter font from Google Fonts */
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
 
+/* Define the default slideover widths */
 :root {
     --slideover-default-lr: 40vw;
     --slideover-default-tb: 80vw;
@@ -64,6 +65,7 @@
     align-items: left;
 }
 
+/* Global slideover container styling */
 .slideover__content {
     position: fixed;
     background: #eaf8fa;
@@ -80,6 +82,7 @@
     margin: 0;
 }
 
+/* Right-aligned slideover effects */
 .slideover--r.slideover__content {
     top: 50%;
     right: 0;
@@ -110,6 +113,7 @@
     transform: translateY(-50%) translateX(0);
 }
 
+/* Bottom-aligned slideover effects */
 .slideover--b.slideover__content {
     bottom: 0;
     left: 50%;
@@ -129,6 +133,24 @@
     transform: translateX(-50%) translateY(0);
 }
 
+.slideover--b .slideover__header {
+    justify-content: flex-end;
+    padding-right: 16px;
+    margin: 0 -20px;
+    border-radius: 8px 8px 0 0;
+    background: transparent;
+}
+
+.slideover--b .slideover__content-area {
+    margin-left: -20px;
+    margin-right: -20px;
+    padding-left: 3rem;
+    padding-right: 3rem;
+    text-align: left;
+    background: #eaf8fa;
+}
+
+/* Top-aligned slideover effects */
 .slideover--t.slideover__content {
     top: 0;
     left: 50%;
@@ -166,6 +188,7 @@
     background: #eaf8fa;
 }
 
+/* Slideover header styling */
 .slideover__header {
     height: 40px;
     display: flex;
@@ -181,6 +204,7 @@
     pointer-events: auto;
 }
 
+/* Toggle-arrow styling */
 .slideover__toggle {
     display: flex;
     align-items: center;
@@ -233,7 +257,7 @@
     transform: rotate(0deg); /* Closed: down arrow */
 }
 
-
+/* Global slideover content area styling */
 .slideover__content-area {
     padding: 0 1.5rem 1.5rem;
     overflow-y: auto;
@@ -243,7 +267,7 @@
     margin: -40px 0 0 0;
     position: relative;
     z-index: 2;
-    padding-top: 25px; 
+    padding-top: 25px;
     opacity: 1;
     visibility: visible;
     transition: opacity 0.3s ease-in-out, visibility 0.3s ease-in-out;
@@ -267,23 +291,6 @@
     margin-top: 0;
     padding-top: 0;
     padding-block-start: 0;
-}
-
-.slideover--b .slideover__header {
-    justify-content: flex-end;
-    padding-right: 16px;
-    margin: 0 -20px;
-    border-radius: 8px 8px 0 0;
-    background: transparent;
-}
-
-.slideover--b .slideover__content-area {
-    margin-left: -20px;
-    margin-right: -20px;
-    padding-left: 3rem;
-    padding-right: 3rem;
-    text-align: left;
-    background: #eaf8fa;
 }
 
 @media screen and (max-width: 800px) {

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -371,21 +371,26 @@
 
 /* Other elements */
 
+/* Callout embed */
+.slideover__content-area .embed {
+    margin-left: 25px;
+    padding-left: 20px;
+    padding-top: 0px;
+    font-size: 0.9em;
+    border-radius: 5px;
+}
+
 /* Quotations */
 .quote {
     font-style: italic;
-    color: #555;
-    border-left: 3px solid #083e44;
     padding-left: 1em;
     margin: 0.5em 0;
     display: inline-block;
 } 
 
 .slideover__content-area blockquote {
-    border-left: 4px solid #083e44;
     margin: 1em 0;
     padding-left: 1em;
-    color: #555;
 }
 
 /* Emphasis */
@@ -400,24 +405,20 @@
 /* Code blocks */
 .slideover__content-area div.sourceCode {
     font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
-    color: #003b4f;
     font-size: 0.9em;
-    background-color: #f5fcfd;
     padding: 0.4em 0.6em;
-    border: 1px solid rgba(8, 62, 68, 0.2);
-    border-radius: 3px;
 }
 
 .slideover__content-area code {
-    background-color: #f5fcfd;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+    font-size: 0.9em;
     padding: 0.1em 0.2em;
-    border-radius: 3px;
+    border-radius: 5px;
 }
 
 .slideover__content-area pre.numberSource {
   margin-left: 1em;
   border-left: none;
-  background-color: #f5fcfd;
   padding-left: 4px;
 }
 

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -68,9 +68,9 @@
 /* Global slideover container styling */
 .slideover__content {
     position: fixed;
-    background: #eaf8fa;
+    /* background: #eaf8fa;
     color: #083e44;
-    border: 1px solid #083e44;
+    border: 1px solid #083e44; */
     box-shadow: -2px 0 4px rgba(8, 62, 68, 0.1), 0 0 4px rgba(8, 62, 68, 0.1);
     transition: transform 0.3s ease-in-out;
     pointer-events: auto;
@@ -91,7 +91,7 @@
     cursor: pointer;
     flex-shrink: 0;
     padding: 0 8px;
-    background: #eaf8fa;
+    /* background: #eaf8fa; */
     margin: 0;
     position: relative;
     z-index: 3;
@@ -102,8 +102,8 @@
 .slideover__content-area {
     padding: 0 1.5rem 1.5rem;
     overflow-y: auto;
-    background: #eaf8fa;
-    color: #083e44;
+    /* background: #eaf8fa;
+    color: #083e44; */
     line-height: 1.5;
     margin: -40px 0 0 0;
     position: relative;
@@ -240,7 +240,7 @@
     padding-left: 3rem;
     padding-right: 3rem;
     text-align: left;
-    background: #eaf8fa;
+    /* background: #eaf8fa; */
 }
 
 .slideover--b.slideover__content.slideover__content--active {
@@ -278,7 +278,7 @@
     padding-right: 3rem;
     padding-top: 0px;
     text-align: left;
-    background: #eaf8fa;
+    /* background: #eaf8fa; */
 }
 
 .slideover--t.slideover__content.slideover__content--active {
@@ -301,7 +301,7 @@
     width: 24px;
     height: 24px;
     transition: transform 0.3s ease;
-    color: #083e44;
+    /* color: #083e44; */
     cursor: pointer;
     position: absolute;
     top: 8px;

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -68,9 +68,7 @@
 /* Global slideover container styling */
 .slideover__content {
     position: fixed;
-    /* background: #eaf8fa;
-    color: #083e44;
-    border: 1px solid #083e44; */
+    /* border: 1px solid #083e44; */
     box-shadow: -2px 0 4px rgba(8, 62, 68, 0.1), 0 0 4px rgba(8, 62, 68, 0.1);
     transition: transform 0.3s ease-in-out;
     pointer-events: auto;
@@ -91,7 +89,6 @@
     cursor: pointer;
     flex-shrink: 0;
     padding: 0 8px;
-    /* background: #eaf8fa; */
     margin: 0;
     position: relative;
     z-index: 3;
@@ -102,8 +99,6 @@
 .slideover__content-area {
     padding: 0 1.5rem 1.5rem;
     overflow-y: auto;
-    /* background: #eaf8fa;
-    color: #083e44; */
     line-height: 1.5;
     margin: -40px 0 0 0;
     position: relative;
@@ -240,7 +235,6 @@
     padding-left: 3rem;
     padding-right: 3rem;
     text-align: left;
-    /* background: #eaf8fa; */
 }
 
 .slideover--b.slideover__content.slideover__content--active {
@@ -278,7 +272,6 @@
     padding-right: 3rem;
     padding-top: 0px;
     text-align: left;
-    /* background: #eaf8fa; */
 }
 
 .slideover--t.slideover__content.slideover__content--active {
@@ -301,7 +294,6 @@
     width: 24px;
     height: 24px;
     transition: transform 0.3s ease;
-    /* color: #083e44; */
     cursor: pointer;
     position: absolute;
     top: 8px;

--- a/_extensions/nrichers/slideover/slideover.css
+++ b/_extensions/nrichers/slideover/slideover.css
@@ -119,6 +119,47 @@
   margin: -20px 0;
 }
 
+/* Left-aligned slideover effects */
+.slideover--l.slideover__content {
+    top: 50%;
+    left: 0;
+    right: auto;
+    height: auto;
+    max-height: 80vh;
+    width: var(--slideover-default-lr);
+    max-width: 100vw;
+    box-sizing: border-box;
+    transform: translateY(-50%) translateX(calc(-100% + 60px));
+    transition: transform 0.3s cubic-bezier(.4,0,.2,1);
+    display: flex;
+    flex-direction: column;
+    padding: 20px;
+    border-radius: 0 8px 8px 0;
+    overflow: hidden;
+}
+
+.slideover--l .slideover__content-area {
+    flex: 1;
+    overflow-y: auto;
+    margin-top: -20px;
+    margin-bottom: -20px;
+    padding: 40px 1.5rem 1.5rem;
+}
+
+.slideover--l.slideover__content.slideover__content--active {
+    transform: translateY(-50%) translateX(0);
+}
+
+
+.slideover--l .slideover__header {
+    margin: -20px 0;
+}
+
+.slideover--l .slideover__content-area {
+    margin-top: -20px;
+    margin-bottom: -20px;
+}
+
 /* Bottom-aligned slideover effects */
 .slideover--b.slideover__content {
     bottom: 0;
@@ -387,45 +428,5 @@
   border-left: none;
   background-color: #f5fcfd;
   padding-left: 4px;
-}
-
-.slideover--l.slideover__content {
-    top: 50%;
-    left: 0;
-    right: auto;
-    height: auto;
-    max-height: 80vh;
-    width: var(--slideover-default-lr);
-    max-width: 100vw;
-    box-sizing: border-box;
-    transform: translateY(-50%) translateX(calc(-100% + 60px));
-    transition: transform 0.3s cubic-bezier(.4,0,.2,1);
-    display: flex;
-    flex-direction: column;
-    padding: 20px;
-    border-radius: 0 8px 8px 0;
-    overflow: hidden;
-}
-
-.slideover--l .slideover__content-area {
-    flex: 1;
-    overflow-y: auto;
-    margin-top: -20px;
-    margin-bottom: -20px;
-    padding: 40px 1.5rem 1.5rem;
-}
-
-.slideover--l.slideover__content.slideover__content--active {
-    transform: translateY(-50%) translateX(0);
-}
-
-
-.slideover--l .slideover__header {
-    margin: -20px 0;
-}
-
-.slideover--l .slideover__content-area {
-    margin-top: -20px;
-    margin-bottom: -20px;
 }
 


### PR DESCRIPTION
> This resolves Issue https://github.com/nrichers/slideover/issues/14.

To enable users to more easily modify the default themed elements, I:

- Cleaned up `slideover.css` — There were a bunch of weird duplicate styles, for example, and some things not in a logical or correct cascading best practice order, etc.
- `_extension.yml` now accommodates for a custom stylesheet on top of the default logic that makes the slideovers work (that can be edited or replaced with one's own template) ...
- ... called `custom-slideover.css` — This contains the default styles for the main elements as an example, with handy variables for commonly used colour elements so users only need to change the variable if they want the colour to apply across the board.
- README has also been updated:
![Screenshot 2025-05-29 at 11 31 57 AM](https://github.com/user-attachments/assets/2d4b78c5-d9b7-4bba-b0af-ee9ed799616f)

This also allows us to update the extension over in the `validmind/documentation` repo, then easily reapply our `validmind-slideover.css` template. 🎉 